### PR TITLE
edit _document title spacing

### DIFF
--- a/pages/_document.js
+++ b/pages/_document.js
@@ -12,7 +12,7 @@ class MyDocument extends Document {
     return (
       <Html>
         <Head>
-          <title>Sami Al Aloosi| Software Enginear </title>
+          <title>Sami Al Aloosi | Software Engineer </title>
           <link rel="icon" href="/images/Logo.svg" />
           <meta name="viewport" content="width=device-width, initial-scale=1.0"></meta>
           <meta name="author" content="Sami Al Aloosi"></meta>


### PR DESCRIPTION
I noticed there was a typo in the website title, so I went ahead an fixed it for you :)

Also, I wanted to mention that you should look into ['react-helmet'](https://www.npmjs.com/package/react-helmet). This is a npm package that attaches site meta data to each page, which will allow search engines to understand/read about your site.

Instead of hard-coding the website title in `_document.js`, you could save the title in a config file instead. Later on, your components could access the values (like 'siteTitle') from a config file, that way you would only have to change in in one place. Check out [this article](https://nextjs.org/docs/api-reference/next.config.js/introduction)